### PR TITLE
Fixing missing locale-gen command

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -2,14 +2,16 @@ FROM ubuntu:16.04
 
 MAINTAINER Daniel Lucas
 
+RUN apt-get update \
+    && apt-get install -y locales
+
 RUN locale-gen en_US.UTF-8
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-RUN apt-get update \
-    && apt-get install -y nginx curl zip unzip git software-properties-common supervisor sqlite3 \
+RUN apt-get install -y nginx curl zip unzip git software-properties-common supervisor sqlite3 \
     && add-apt-repository -y ppa:ondrej/php \
     && apt-get update \
     && apt-get install -y php7.0-fpm php7.0-cli php7.0-mcrypt php7.0-gd php7.0-mysql \


### PR DESCRIPTION
Error was:

Step 3/15 : RUN locale-gen en_US.UTF-8
 ---> Running in 35c573bc2b79
/bin/sh: 1: locale-gen: not found
ERROR: Service 'app' failed to build: The command '/bin/sh -c locale-gen en_US.UTF-8' returned a non-zero code: 127